### PR TITLE
Standalone Package supporting wider Package use and Development

### DIFF
--- a/chrome/capabilities.go
+++ b/chrome/capabilities.go
@@ -14,7 +14,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/tebeka/selenium/internal/zip"
+	"github.com/saucelabs/selenium/internal/zip"
 )
 
 // CapabilitiesKey is the key in the top-level Capabilities map under which

--- a/example_test.go
+++ b/example_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tebeka/selenium"
+	"github.com/saucelabs/selenium"
 )
 
 // This example shows how to navigate to a http://play.golang.org page, input a

--- a/firefox/capabilities.go
+++ b/firefox/capabilities.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"encoding/base64"
 
-	"github.com/tebeka/selenium/internal/zip"
+	"github.com/saucelabs/selenium/internal/zip"
 )
 
 // CapabilitiesKey is the name of the Firefox-specific key in the WebDriver

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,7 @@ google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+google.golang.org/appengine v1.6.1 h1:QzqyMA1tlu6CgqCDUtU9V+ZKhLFT2dkJuANu5QaxI3I=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/internal/seleniumtest/seleniumtest.go
+++ b/internal/seleniumtest/seleniumtest.go
@@ -24,11 +24,11 @@ import (
 	socks5 "github.com/armon/go-socks5"
 	"github.com/blang/semver"
 	"github.com/google/go-cmp/cmp"
-	"github.com/tebeka/selenium"
-	"github.com/tebeka/selenium/chrome"
-	"github.com/tebeka/selenium/firefox"
-	"github.com/tebeka/selenium/log"
-	"github.com/tebeka/selenium/sauce"
+	"github.com/saucelabs/selenium"
+	"github.com/saucelabs/selenium/chrome"
+	"github.com/saucelabs/selenium/firefox"
+	"github.com/saucelabs/selenium/log"
+	"github.com/saucelabs/selenium/sauce"
 )
 
 type Config struct {

--- a/remote.go
+++ b/remote.go
@@ -18,8 +18,8 @@ import (
 	"time"
 
 	"github.com/blang/semver"
-	"github.com/tebeka/selenium/firefox"
-	"github.com/tebeka/selenium/log"
+	"github.com/saucelabs/selenium/firefox"
+	"github.com/saucelabs/selenium/log"
 )
 
 // Errors returned by Selenium server.

--- a/remote_test.go
+++ b/remote_test.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/golang/glog"
-	"github.com/tebeka/selenium"
-	"github.com/tebeka/selenium/internal/seleniumtest"
+	"github.com/saucelabs/selenium"
+	"github.com/saucelabs/selenium/internal/seleniumtest"
 )
 
 var (

--- a/sauce_test.go
+++ b/sauce_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
-	"github.com/tebeka/selenium"
-	"github.com/tebeka/selenium/internal/seleniumtest"
-	"github.com/tebeka/selenium/sauce"
+	"github.com/saucelabs/selenium"
+	"github.com/saucelabs/selenium/internal/seleniumtest"
+	"github.com/saucelabs/selenium/sauce"
 )
 
 var (

--- a/selenium.go
+++ b/selenium.go
@@ -3,9 +3,9 @@ package selenium
 import (
 	"time"
 
-	"github.com/tebeka/selenium/chrome"
-	"github.com/tebeka/selenium/firefox"
-	"github.com/tebeka/selenium/log"
+	"github.com/saucelabs/selenium/chrome"
+	"github.com/saucelabs/selenium/firefox"
+	"github.com/saucelabs/selenium/log"
 )
 
 // TODO(minusnine): make an enum type called FindMethod.


### PR DESCRIPTION
It seems Go packages resist forking a bit.  Looking to expand the use of the package which fails to install in certain circumstances, as well as support this repo passing tests under it's package namespace `saucelabs/selenium`.

Not sure if there's a good clean best practice for this, initial searching was not very helpful.  From use of other package managers this type of fork trouble seems par for the course, but will likely clutter merging from upstream a bit.  Expecting this, the approach here is to minimize changes, focusing on immediate goals only:

* have `go mod tidy` run without complaint
* allow `go test` to start
* allow `RUN go get -t -d github.com/saucelabs/selenium` to succeed in a docker container

**Extended Goal** - eliminate overlapping `github.com/tebeka/selenium v0.9.9` added by `go mod tidy`.  Reasons:
* debugging expected to be perilous with potentially multiple packages providing (nearly) identical code
* seems the correct way (not an expert)

Opening commit still requires a `go mod tidy` as I didn't include the `github.com/tebeka/selenium v0.9.9` that tidy automatically adds to go.mod.  The intention of that first commit was a reference point where a minimum code change allowed tidy to actually complete without complaint, and for `go test` to start without complaint.

Also if I had to change any dep within a file, I changed them all in that file.